### PR TITLE
tensor linked with parents & children

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,30 +6,14 @@
 int main()
 {
     log_set_level(LOG_INFO);
-    clock_t start, end;
-    double cpu_time_used;
+    tensor_t *a = tensor_rand((int[]){2, 3}, 2, false);
+    tensor_t *b = tensor_rand((int[]){2, 3}, 2, false);
+    tensor_t *c = tensor_rand((int[]){2, 3}, 2, false);
 
-    tensor_t *a = tensor_rand((int[]){3, 200, 200}, 3, false);
+    tensor_t *d = tensor_add(a, b);
+    tensor_t *e = tensor_add(b, c);
+    tensor_t *f = tensor_add(d, e);
 
-    start = clock();
-    iterator_t it = tensor_iterator(a);
-    while (iterator_has_next(&it))
-    {
-        int index = iterator_next(&it);
-        a->data[index] = a->data[index] * 2;
-    }
-    iterator_free(&it);
-    end = clock();
-    cpu_time_used = ((double)(end - start)) / CLOCKS_PER_SEC;
-    printf("Time taken by Method 1: %f\n", cpu_time_used);
-
-    start = clock();
-    for (int i = 0; i < a->size; i++)
-    {
-        a->data[i] = a->data[i] * 2;
-    }
-    end = clock();
-    cpu_time_used = ((double)(end - start)) / CLOCKS_PER_SEC;
-    printf("Time taken by Method 2: %f\n", cpu_time_used);
+    tensor_free(f, true);
     return 0;
 }

--- a/src/backops.c
+++ b/src/backops.c
@@ -7,9 +7,9 @@ void backward(tensor_t *self)
         log_debug("Node %p has no backward function.", (void *)self);
         return;
     }
-    if (self->children == NULL)
+    if (self->parents == NULL)
     {
-        log_debug("Node %p has no children.", (void *)self);
+        log_debug("Node %p has no parents.", (void *)self);
         return;
     }
     self->backward(self);
@@ -24,163 +24,163 @@ void init_grad(tensor_t *self)
 }
 
 // BACKWARD
-void update_grad_add(tensor_t *self, tensor_t *child)
+void update_grad_add(tensor_t *self, tensor_t *parent)
 {
-    if (!child->requires_grad)
+    if (!parent->requires_grad)
         return;
 
     for (int i = 0; i < self->size; i++)
     {
-        child->grad[i] += self->grad[i];
+        parent->grad[i] += self->grad[i];
     }
 }
 
-void update_grad_relu(tensor_t *self, tensor_t *child)
+void update_grad_relu(tensor_t *self, tensor_t *parent)
 {
-    if (!child->requires_grad)
+    if (!parent->requires_grad)
         return;
     for (int i = 0; i < self->size; i++)
     {
-        child->grad[i] += self->grad[i] * (self->data[i] > 0);
+        parent->grad[i] += self->grad[i] * (self->data[i] > 0);
     }
 }
 
-void update_grad_mul(tensor_t *self, tensor_t *child, tensor_t *other)
+void update_grad_mul(tensor_t *self, tensor_t *parent, tensor_t *other)
 {
-    if (!child->requires_grad)
+    if (!parent->requires_grad)
         return;
 
     int k;
     for (int i = 0; i < self->size; i++)
     {
         k = (other->size == 1) ? 0 : i;
-        child->grad[i] += self->grad[i] * other->data[k];
+        parent->grad[i] += self->grad[i] * other->data[k];
     }
 }
 
-void update_grad_pow(tensor_t *self, tensor_t *child, tensor_t *other)
+void update_grad_pow(tensor_t *self, tensor_t *parent, tensor_t *other)
 {
-    if (!child->requires_grad)
+    if (!parent->requires_grad)
         return;
 
     int k;
     for (int i = 0; i < self->size; i++)
     {
         k = (other->size == 1) ? 0 : i;
-        child->grad[i] += self->grad[i] * other->data[k] * powf(child->data[i], other->data[k] - 1);
+        parent->grad[i] += self->grad[i] * other->data[k] * powf(parent->data[i], other->data[k] - 1);
     }
 }
 
-void update_grad_exp(tensor_t *self, tensor_t *child, tensor_t *other)
+void update_grad_exp(tensor_t *self, tensor_t *parent, tensor_t *other)
 {
-    if (!child->requires_grad)
+    if (!parent->requires_grad)
         return;
 
     int k;
     for (int i = 0; i < self->size; i++)
     {
         k = (other->size == 1) ? 0 : i;
-        child->grad[i] += self->grad[i] * self->data[i] * logf(other->data[k]);
+        parent->grad[i] += self->grad[i] * self->data[i] * logf(other->data[k]);
     }
 }
 
-void update_grad_sum(tensor_t *self, tensor_t *child)
+void update_grad_sum(tensor_t *self, tensor_t *parent)
 {
-    if (!child->requires_grad)
+    if (!parent->requires_grad)
         return;
-    for (int i = 0; i < child->size; i++)
+    for (int i = 0; i < parent->size; i++)
     {
-        child->grad[i] += self->grad[0];
+        parent->grad[i] += self->grad[0];
     }
 }
 
 // UNARY OPS
 void backward_relu(tensor_t *self)
 {
-    ASSERT(self->n_children == 1, "backward_relu expects 1 child, got %d", self->n_children);
-    init_grad(self->children[0]);
-    update_grad_relu(self, self->children[0]);
-    backward(self->children[0]);
+    ASSERT(self->n_parents == 1, "backward_relu expects 1 parent, got %d", self->n_parents);
+    init_grad(self->parents[0]);
+    update_grad_relu(self, self->parents[0]);
+    backward(self->parents[0]);
 }
 
 // BINARY OPS
 void backward_add(tensor_t *self)
 {
-    ASSERT(self->n_children == 2, "backward_add expects 2 children, got %d", self->n_children);
-    init_grad(self->children[0]);
-    init_grad(self->children[1]);
+    ASSERT(self->n_parents == 2, "backward_add expects 2 parents, got %d", self->n_parents);
+    init_grad(self->parents[0]);
+    init_grad(self->parents[1]);
 
-    update_grad_add(self, self->children[0]);
-    update_grad_add(self, self->children[1]);
+    update_grad_add(self, self->parents[0]);
+    update_grad_add(self, self->parents[1]);
 
-    backward(self->children[0]);
-    backward(self->children[1]);
+    backward(self->parents[0]);
+    backward(self->parents[1]);
 }
 
 void backward_mul(tensor_t *self)
 {
-    ASSERT(self->n_children == 2, "backward_mul expects 2 children, got %d", self->n_children);
-    init_grad(self->children[0]);
-    init_grad(self->children[1]);
+    ASSERT(self->n_parents == 2, "backward_mul expects 2 parents, got %d", self->n_parents);
+    init_grad(self->parents[0]);
+    init_grad(self->parents[1]);
 
-    update_grad_mul(self, self->children[0], self->children[1]);
-    update_grad_mul(self, self->children[1], self->children[0]);
+    update_grad_mul(self, self->parents[0], self->parents[1]);
+    update_grad_mul(self, self->parents[1], self->parents[0]);
 
-    backward(self->children[0]);
-    backward(self->children[1]);
+    backward(self->parents[0]);
+    backward(self->parents[1]);
 }
 
 void backward_pow(tensor_t *self)
 {
-    ASSERT(self->n_children == 2, "backward_pow expects 2 children, got %d", self->n_children);
-    init_grad(self->children[0]);
-    init_grad(self->children[1]);
+    ASSERT(self->n_parents == 2, "backward_pow expects 2 parents, got %d", self->n_parents);
+    init_grad(self->parents[0]);
+    init_grad(self->parents[1]);
 
-    update_grad_pow(self, self->children[0], self->children[1]);
-    update_grad_exp(self, self->children[1], self->children[0]);
+    update_grad_pow(self, self->parents[0], self->parents[1]);
+    update_grad_exp(self, self->parents[1], self->parents[0]);
 
-    backward(self->children[0]);
-    backward(self->children[1]);
+    backward(self->parents[0]);
+    backward(self->parents[1]);
 }
 
 // REDUCE OPS
 void backward_sum(tensor_t *self)
 {
-    ASSERT(self->n_children == 1, "backward_sum expects 1 child, got %d", self->n_children);
-    init_grad(self->children[0]);
-    update_grad_sum(self, self->children[0]);
-    backward(self->children[0]);
+    ASSERT(self->n_parents == 1, "backward_sum expects 1 parent, got %d", self->n_parents);
+    init_grad(self->parents[0]);
+    update_grad_sum(self, self->parents[0]);
+    backward(self->parents[0]);
 }
 
 // MOVEMENT OPS
 void backward_ref(tensor_t *self)
 {
-    ASSERT(self->n_children > 0, "backward_ref expects at least 1 child, got %d", self->n_children);
-    for (int i = 0; i < self->n_children; i++)
+    ASSERT(self->n_parents > 0, "backward_ref expects at least 1 parent, got %d", self->n_parents);
+    for (int i = 0; i < self->n_parents; i++)
     {
-        self->children[i]->grad = sref(self->grad);
-        backward(self->children[i]);
+        self->parents[i]->grad = sref(self->grad);
+        backward(self->parents[i]);
     }
 }
 
 void backward_slice(tensor_t *self)
 {
-    ASSERT(self->n_children == 1, "backward_slice expects 1 child, got %d", self->n_children);
-    init_grad(self->children[0]);
+    ASSERT(self->n_parents == 1, "backward_slice expects 1 parent, got %d", self->n_parents);
+    init_grad(self->parents[0]);
     iterator_t it = tensor_iterator(self);
-    copy_to_range(self->children[0]->grad, self->grad, &it);
+    copy_to_range(self->parents[0]->grad, self->grad, &it);
     iterator_free(&it);
     sfree(self->grad);
-    self->grad = sref(self->children[0]->grad);
-    backward(self->children[0]);
+    self->grad = sref(self->parents[0]->grad);
+    backward(self->parents[0]);
 }
 
 void backward_copy(tensor_t *self)
 {
-    ASSERT(self->n_children == 1, "backward_copy expects 1 child, got %d", self->n_children);
-    init_grad(self->children[0]);
+    ASSERT(self->n_parents == 1, "backward_copy expects 1 parent, got %d", self->n_parents);
+    init_grad(self->parents[0]);
     iterator_t it = tensor_iterator(self);
-    copy_to_range(self->children[0]->grad, self->grad, &it);
+    copy_to_range(self->parents[0]->grad, self->grad, &it);
     iterator_free(&it);
-    backward(self->children[0]);
+    backward(self->parents[0]);
 }

--- a/src/backops.h
+++ b/src/backops.h
@@ -7,12 +7,12 @@ void backward(tensor_t *self);
 void init_grad(tensor_t *self);
 
 // BACKWARD
-void update_grad_relu(tensor_t *self, tensor_t *child);
-void update_grad_add(tensor_t *self, tensor_t *child);
-void update_grad_mul(tensor_t *self, tensor_t *child, tensor_t *other);
-void update_grad_pow(tensor_t *self, tensor_t *child, tensor_t *other);
-void update_grad_exp(tensor_t *self, tensor_t *child, tensor_t *other);
-void update_grad_sum(tensor_t *self, tensor_t *child);
+void update_grad_relu(tensor_t *self, tensor_t *parent);
+void update_grad_add(tensor_t *self, tensor_t *parent);
+void update_grad_mul(tensor_t *self, tensor_t *parent, tensor_t *other);
+void update_grad_pow(tensor_t *self, tensor_t *parent, tensor_t *other);
+void update_grad_exp(tensor_t *self, tensor_t *parent, tensor_t *other);
+void update_grad_sum(tensor_t *self, tensor_t *parent);
 
 // UNARY OPS
 void backward_relu(tensor_t *self);

--- a/src/ops.c
+++ b/src/ops.c
@@ -22,127 +22,127 @@ void free_data(tensor_t *self)
 // if not, use iterator to iterate over data
 
 // FORWARD
-void relut(tensor_t *self, tensor_t *child)
+void relut(tensor_t *self, tensor_t *parent)
 {
     for (int i = 0; i < self->size; i++)
     {
-        self->data[i] = (child->data[i] > 0.0) ? child->data[i] : 0.0;
+        self->data[i] = (parent->data[i] > 0.0) ? parent->data[i] : 0.0;
     }
 }
 
-void addt(tensor_t *self, tensor_t *child, tensor_t *other)
-{
-    int j, k;
-    for (int i = 0; i < self->size; i++)
-    {
-        j = (child->size == 1) ? 0 : i;
-        k = (other->size == 1) ? 0 : i;
-        self->data[i] = child->data[j] + other->data[k];
-    }
-}
-
-void mult(tensor_t *self, tensor_t *child, tensor_t *other)
+void addt(tensor_t *self, tensor_t *parent, tensor_t *other)
 {
     int j, k;
     for (int i = 0; i < self->size; i++)
     {
-        j = (child->size == 1) ? 0 : i;
+        j = (parent->size == 1) ? 0 : i;
         k = (other->size == 1) ? 0 : i;
-        self->data[i] = child->data[j] * other->data[k];
+        self->data[i] = parent->data[j] + other->data[k];
     }
 }
 
-void powt(tensor_t *self, tensor_t *child, tensor_t *other)
+void mult(tensor_t *self, tensor_t *parent, tensor_t *other)
 {
     int j, k;
     for (int i = 0; i < self->size; i++)
     {
-        j = (child->size == 1) ? 0 : i;
+        j = (parent->size == 1) ? 0 : i;
         k = (other->size == 1) ? 0 : i;
-        self->data[i] = powf(child->data[j], other->data[k]);
+        self->data[i] = parent->data[j] * other->data[k];
     }
 }
 
-void sumt(tensor_t *self, tensor_t *child)
+void powt(tensor_t *self, tensor_t *parent, tensor_t *other)
+{
+    int j, k;
+    for (int i = 0; i < self->size; i++)
+    {
+        j = (parent->size == 1) ? 0 : i;
+        k = (other->size == 1) ? 0 : i;
+        self->data[i] = powf(parent->data[j], other->data[k]);
+    }
+}
+
+void sumt(tensor_t *self, tensor_t *parent)
 {
     *self->data = 0.0;
-    iterator_t it = tensor_iterator(child);
+    iterator_t it = tensor_iterator(parent);
     while (iterator_has_next(&it))
     {
-        *self->data += child->data[iterator_next(&it)];
+        *self->data += parent->data[iterator_next(&it)];
     }
     iterator_free(&it);
 }
 
-void catt(tensor_t *self, tensor_t *children[], int n_children)
+void catt(tensor_t *self, tensor_t *parents[], int n_parents)
 {
-    for (int i = 0; i < n_children; i++)
+    for (int i = 0; i < n_parents; i++)
     {
-        iterator_t it = tensor_iterator(children[i]);
-        copy_to_range(self->data, children[i]->data, &it);
+        iterator_t it = tensor_iterator(parents[i]);
+        copy_to_range(self->data, parents[i]->data, &it);
         iterator_free(&it);
-        sfree(children[i]->data);
-        children[i]->data = sref(self->data);
+        sfree(parents[i]->data);
+        parents[i]->data = sref(self->data);
     }
 }
 
 // UNARY OPS
 void forward_relu(tensor_t *self)
 {
-    ASSERT(self->n_children == 1, "forward_relu must have 1 child, got %d", self->n_children);
+    ASSERT(self->n_parents == 1, "forward_relu must have 1 parent, got %d", self->n_parents);
     init_data(self);
-    relut(self, self->children[0]);
+    relut(self, self->parents[0]);
 }
 
 // BINARY OPS
 void forward_add(tensor_t *self)
 {
-    ASSERT(self->n_children == 2, "forward_add must have 2 children, got %d", self->n_children);
+    ASSERT(self->n_parents == 2, "forward_add must have 2 parents, got %d", self->n_parents);
     init_data(self);
-    addt(self, self->children[0], self->children[1]);
+    addt(self, self->parents[0], self->parents[1]);
 }
 
 void forward_mul(tensor_t *self)
 {
-    ASSERT(self->n_children == 2, "forward_mul must have 2 children, got %d", self->n_children);
+    ASSERT(self->n_parents == 2, "forward_mul must have 2 parents, got %d", self->n_parents);
     init_data(self);
-    mult(self, self->children[0], self->children[1]);
+    mult(self, self->parents[0], self->parents[1]);
 }
 
 void forward_pow(tensor_t *self)
 {
-    ASSERT(self->n_children == 2, "forward_pow must have 2 children, got %d", self->n_children);
+    ASSERT(self->n_parents == 2, "forward_pow must have 2 parents, got %d", self->n_parents);
     init_data(self);
-    powt(self, self->children[0], self->children[1]);
+    powt(self, self->parents[0], self->parents[1]);
 }
 
 // REDUCE OPS
 void forward_sum(tensor_t *self)
 {
-    ASSERT(self->n_children == 1, "forward_sum must have 1 child, got %d", self->n_children);
+    ASSERT(self->n_parents == 1, "forward_sum must have 1 parent, got %d", self->n_parents);
     init_data(self);
-    sumt(self, self->children[0]);
+    sumt(self, self->parents[0]);
 }
 
 // MOVEMENT OPS
 void forward_cat(tensor_t *self)
 {
-    ASSERT(self->n_children > 0, "forward_cat must have at least 1 child, got %d", self->n_children);
+    ASSERT(self->n_parents > 0, "forward_cat must have at least 1 parent, got %d", self->n_parents);
     init_data(self);
-    catt(self, self->children, self->n_children);
+    catt(self, self->parents, self->n_parents);
 }
 
 void forward_copy(tensor_t *self)
 {
-    ASSERT(self->n_children == 1, "forward_copy must have 1 child, got %d", self->n_children);
+    ASSERT(self->n_parents == 1, "forward_copy must have 1 parent, got %d", self->n_parents);
     init_data(self);
     iterator_t it = tensor_iterator(self);
-    copy_from_range(self->data, self->children[0]->data, &it);
+    copy_from_range(self->data, self->parents[0]->data, &it);
     iterator_free(&it);
 }
 
 void forward_ref(tensor_t *self)
 {
-    ASSERT(self->n_children == 1, "forward_ref must have 1 child, got %d", self->n_children);
-    self->data = sref(self->children[0]->data);
+    ASSERT(self->n_parents == 1, "forward_ref must have 1 parent, got %d", self->n_parents);
+    self->data = sref(self->parents[0]->data);
 }

--- a/src/ops.h
+++ b/src/ops.h
@@ -7,12 +7,12 @@ void init_data(tensor_t *self);
 void free_data(tensor_t *self);
 
 // FORWARD
-void relut(tensor_t *self, tensor_t *child);
-void addt(tensor_t *self, tensor_t *child, tensor_t *other);
-void mult(tensor_t *self, tensor_t *child, tensor_t *other);
-void powt(tensor_t *self, tensor_t *child, tensor_t *other);
-void sumt(tensor_t *self, tensor_t *child);
-void catt(tensor_t *self, tensor_t *children[], int n_children);
+void relut(tensor_t *self, tensor_t *parent);
+void addt(tensor_t *self, tensor_t *parent, tensor_t *other);
+void mult(tensor_t *self, tensor_t *parent, tensor_t *other);
+void powt(tensor_t *self, tensor_t *parent, tensor_t *other);
+void sumt(tensor_t *self, tensor_t *parent);
+void catt(tensor_t *self, tensor_t *parents[], int n_parents);
 
 // UNARY OPS
 void forward_relu(tensor_t *self);

--- a/src/tensor.h
+++ b/src/tensor.h
@@ -33,6 +33,9 @@ typedef struct tensor
     int *stride;
     slice_t *range;
 
+    int n_parents;
+    struct tensor **parents;
+
     int n_children;
     struct tensor **children;
 
@@ -45,7 +48,10 @@ typedef struct tensor
 tensor_t *tensor_alloc(int size);
 tensor_t *tensor_create(int shape[], int ndim, bool requires_grad);
 tensor_t *tensor_init(int shape[], int ndim, bool requires_grad, void (*op)(tensor_t *));
-void tensor_child(tensor_t *parent, tensor_t *child);
+void tensor_link(tensor_t *child, tensor_t *parent);
+
+// DESTRUCT OPS
+void tensor_unlink(tensor_t *child, tensor_t *parent);
 void tensor_free(tensor_t *tensor, bool recursive);
 
 // INIT OPS


### PR DESCRIPTION
This PR solves the double free error appearing when two tensors have a common parent. The idea is to first unlink a tensor's relationship with all its children before freeing it. Because another child has no other way of knowing its parent is dead, the parent must notify him before being freed